### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/functions/events.js
+++ b/functions/events.js
@@ -286,9 +286,7 @@ exports.sendSecretSantaEmails = functions.https.onCall(async (data, context) => 
                           !apiKey ||
                           apiKey.length < 10; // API keys reales son más largas
         
-        console.log('📧 API Key check:', { 
-          hasApiKey: !!apiKey, 
-          keyLength: apiKey?.length || 0, 
+        console.log('📧 Email sending mode:', { 
           isDemoMode,
           isEmulator: process.env.FUNCTIONS_EMULATOR === 'true'
         });


### PR DESCRIPTION
Potential fix for [https://github.com/fnoya/amigoinvisible/security/code-scanning/2](https://github.com/fnoya/amigoinvisible/security/code-scanning/2)

To fix the problem, we should ensure that no sensitive data or any data derived from sensitive values (such as API keys, their length, or their existence) is logged to console output. We should modify the log statement on line 289 so it only outputs non-sensitive, non-derived data. Specifically, remove all mention of `apiKey` (including its presence, length, and demo-mode checks) from logs. If logging is needed for debugging (e.g., to indicate whether in demo mode or production), we should only state `isDemoMode` and other high-level flags, not any API key information or metadata.

- Edit the block around line 289 in `functions/events.js`, removing API key details from the log.
- Ensure only non-sensitive data (e.g., `isDemoMode`, `isEmulator`) is logged.

No new imports or external methods are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
