### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,9 @@
 name: Deploy to Firebase
 
+permissions:
+  contents: read
+  issues: write
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/fnoya/amigoinvisible/security/code-scanning/1](https://github.com/fnoya/amigoinvisible/security/code-scanning/1)

To fix this, add an explicit `permissions:` block to restrict GITHUB_TOKEN privileges for the workflow. The recommended spot is just below the workflow `name:` (i.e., before or after `on:`), making the permissions default for all jobs in the workflow unless overridden at the job level. For this workflow, grant read-only access to `contents`, but allow write-only for `issues` (since PR comment steps use `createComment`). The best fix is to add:

```yaml
permissions:
  contents: read
  issues: write
```

on a new line between line 2 and line 3 in `.github/workflows/deploy.yml`. No further changes are necessary in the existing job or steps.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
